### PR TITLE
Fix Gantt header grid alignment

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,7 +120,7 @@ function bindEvents(){
     // モデル未構築時はスキップ（初回起動のエラーを回避）
     if (!state?.model?.min || !state?.model?.max) return;
     const span = Math.max(1, daysBetween(state.model.min, state.model.max));
-    renderHeader(span, 80);
+    renderHeader(span, 120);
   }).observe(document.getElementById('taskLabels'));
 }
 

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -768,11 +768,14 @@ export function renderHeader(totalDays, RIGHT_PAD){
 
   // ラベル列ぶんだけ押し出す
   const labelsRoot = document.getElementById('taskLabels');
-  const spacerW = (labelsRoot ? labelsRoot.offsetWidth : 0)
+  const resizer    = document.getElementById('colResizer');
+  const labelsW = (labelsRoot ? labelsRoot.offsetWidth : 0)
       || parseInt(getComputedStyle(document.documentElement).getPropertyValue('--labels-w')) || 360;
-  leftHead.style.width = spacerW + 'px';
-  monthRow.style.marginLeft = spacerW + 'px';
-  dayRow.style.marginLeft   = spacerW + 'px';
+  const resizerW = resizer ? resizer.offsetWidth : 0;
+  const offset = labelsW + resizerW;
+  leftHead.style.width = labelsW + 'px';
+  monthRow.style.marginLeft = offset + 'px';
+  dayRow.style.marginLeft   = offset + 'px';
 
   // 可視幅を本体に合わせる
   const w = grid ? grid.scrollWidth : 0;


### PR DESCRIPTION
## Summary
- include column resizer width when positioning header rows so grid lines align
- keep header rendering in sync after label width changes by using consistent padding

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bce937b070832fafb2234322f03757