### PR TITLE
Add Playwright browser tests and GitHub Actions workflow

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,0 +1,15 @@
+name: browser-tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npx playwright install --with-deps
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "csv_gantt_viewer",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.1"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'python -m http.server 3000',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+});

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs/promises';
+import path from 'path';
+
+const sampleCsvPath = path.join(__dirname, '..', 'csv', 'sample.csv');
+
+// テキストエリアにサンプルCSVを入力してレンダリングできるかを確認
+
+test('renders bars from sample CSV', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForSelector('#csvInput');
+  const csv = await fs.readFile(sampleCsvPath, 'utf-8');
+  await page.fill('#csvInput', csv);
+  await page.click('#renderBtn');
+  // バーが生成されるまで待機し、1つ以上あることを確認
+  await page.waitForSelector('#bars .bar');
+  const count = await page.locator('#bars .bar').count();
+  expect(count).toBeGreaterThan(0);
+});

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -8,7 +8,9 @@ const sampleCsvPath = path.join(__dirname, '..', 'csv', 'sample.csv');
 
 test('renders bars from sample CSV', async ({ page }) => {
   await page.goto('/');
-  await page.waitForSelector('#csvInput');
+  // CSV入力モーダルを開いてテキストエリアを表示
+  await page.click('#previewBtn');
+  await page.waitForSelector('#csvInput', { state: 'visible' });
   const csv = await fs.readFile(sampleCsvPath, 'utf-8');
   await page.fill('#csvInput', csv);
   await page.click('#renderBtn');


### PR DESCRIPTION
## Summary
- configure automated Playwright test to render sample CSV and verify bars
- run browser tests in CI via GitHub Actions
- ignore node_modules and test artifacts

## Testing
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1abbd1c8832fb8cf948bb0769b57