### PR TITLE
Add light yellow color for next phase status

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ function statusColor(s){
   if(v==='完了済み') return '#bdbdbd';
   if(v==='開始前') return '#ffffff';
   if(v==='進行中') return '#66bb6a';
-  if(v==='次フェーズ以降') return '#fff9c4';
+  if(v==='次フェーズ以降') return '#bbdefb';
   if(v==='遅延') return '#ffd54f';
   return '#66bb6a';
 }

--- a/app.js
+++ b/app.js
@@ -45,6 +45,7 @@ function statusColor(s){
   if(v==='完了済み') return '#bdbdbd';
   if(v==='開始前') return '#ffffff';
   if(v==='進行中') return '#66bb6a';
+  if(v==='次フェーズ以降') return '#fff9c4';
   if(v==='遅延') return '#ffd54f';
   return '#66bb6a';
 }

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -69,7 +69,7 @@ const statusColor = (window.statusColor) ? window.statusColor : function(s){
   if(v==='完了済み') return '#bdbdbd';
   if(v==='開始前') return '#ffffff';
   if(v==='進行中') return '#66bb6a';
-  if(v==='次フェーズ以降') return '#fff9c4';
+  if(v==='次フェーズ以降') return '#bbdefb';
   if(v==='遅延') return '#ffd54f';
   return '#66bb6a';
 };

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -69,6 +69,7 @@ const statusColor = (window.statusColor) ? window.statusColor : function(s){
   if(v==='完了済み') return '#bdbdbd';
   if(v==='開始前') return '#ffffff';
   if(v==='進行中') return '#66bb6a';
+  if(v==='次フェーズ以降') return '#fff9c4';
   if(v==='遅延') return '#ffd54f';
   return '#66bb6a';
 };


### PR DESCRIPTION
## Summary
- map the "次フェーズ以降" progress status to a light yellow Gantt bar color in both status color helpers

## Testing
- npm test *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68efb1f4eb10832f89c41f8be2e9e5cd